### PR TITLE
Tennessee Volunteers fixes

### DIFF
--- a/ncaa-team-colors.json
+++ b/ncaa-team-colors.json
@@ -2589,8 +2589,9 @@
   {
     "name": "Tennessee Volunteers",
     "colors": [
+      "#FF8200",
       "#FFFFFF",
-      "#EE9627"
+      "#58595B"
     ],
     "id": "b0c9634c-ae2b-476f-b1bb-1c20269cd5c9"
   },


### PR DESCRIPTION
For Tennessee Volunteers:
- Fixed incorrect Primary Color hex code
- Reordered by importance
- Added “Smokey” as a third color
  as per http://brand.utk.edu/colors/palettes/
